### PR TITLE
Summary

### DIFF
--- a/ncr/datastream.py
+++ b/ncr/datastream.py
@@ -519,7 +519,7 @@ class TimedData:
         nnans = 0
         ninfs = 0
         nfill = 0
-        for ns in self.old:
+        for ns in self.data.values():
             a = ns.get_nifs()
             nmiss += a[0] 
             nnans += a[1]
@@ -788,8 +788,9 @@ class Datastream:
         fills = 0 
 
         for key, value in self.variables.items():
-            if value is Variable:
+            if type(value) is Variable:
                 a, b, c, d = value.get_nifs()
+                print(a, b, c, d)
                 nmiss += a
                 nanns += b
                 infs  += c

--- a/ncr/datastream.py
+++ b/ncr/datastream.py
@@ -110,6 +110,38 @@ class DimlessSum:
     def row(self):
         return [self.val]
 
+    def get_nifs(self):
+        '''nmiss, nfill = 0, 0
+        data = np.array(self.row())
+    
+
+        size = int(data.size)
+
+        if hasattr(data, 'mask'):
+            masked = data[data.mask].data
+            nfill = int(np.size(masked))
+            if self.missing_value is not None:
+                nmiss = int(np.sum(masked == self.missing_value))
+            if self.fill_value is not None:
+                nfill = int(np.sum(masked == self.fill_value))
+            elif nfill > 0:
+                nfill -= nmiss
+                        
+            try:
+                nans = np.where(np.isnan(data)) 
+                nnan = int(nans[0].size)
+            except TypeError:
+                nnan = 0
+    
+            try:
+                infs = np.where(np.isinf(data))
+                ninf = int(infs[0].size)
+            except TypeError:
+                ninf = 0'''
+
+
+        return (0, 0, 0, 0)
+
 class NumSum:
     '''Summary of the values in a variable holding numerical data.
 
@@ -577,6 +609,25 @@ class UntimedData(Timeline):
         summ = self.data_type.summarize(sumvar['data'])
         Timeline.load(self, summ)
 
+    def get_nifs(self):
+
+        nmiss = 0
+        nnans = 0
+        ninfs = 0
+        nfill = 0
+
+        print('called')
+
+        for i in self:
+            print(type(i), i, i.val.row())
+            a = (0, 0, 0, 0) if i.val is None else i.val.get_nifs()
+            nmiss += a[0]
+            nnans += a[1]
+            ninfs += a[2]
+            nfill += a[3]
+        
+        return (nmiss, nnans, ninfs, nfill)
+
     def jsonify(self):
 
         columns, tooltips = self.data_type.columns()
@@ -643,9 +694,7 @@ class Variable:
             self.data.load(sumvar)
 
     def get_nifs(self):
-        if type(self.data) is TimedData:
-            return self.data.get_nifs()
-        return (0, 0, 0, 0)
+        return self.data.get_nifs()
 
     def jsonify(self):
         sec = utils.json_section(self, [

--- a/ncr/datastream.py
+++ b/ncr/datastream.py
@@ -616,10 +616,7 @@ class UntimedData(Timeline):
         ninfs = 0
         nfill = 0
 
-        print('called')
-
         for i in self:
-            print(type(i), i, i.val.row())
             a = (0, 0, 0, 0) if i.val is None else i.val.get_nifs()
             nmiss += a[0]
             nnans += a[1]
@@ -836,6 +833,11 @@ class Datastream:
         infs = 0   
         fills = 0 
 
+        #print("----\tOLD\tDATA\t----\t----")
+        #print("miss\tnans\tinfs\tfill\tNAME")
+
+        data = {}
+
         for key, value in self.variables.items():
             if type(value) is Variable:
                 a, b, c, d = value.get_nifs()
@@ -844,6 +846,17 @@ class Datastream:
                 infs  += c
                 fills += d
 
+                if a >0 or b>0 or c>0 or d>0 :
+                    data[value.name] = (a,b,c,d);
+                    '''
+                    for x in (a,b,c,d, value.name):
+                        print(x, end='\t')
+                    print()'''
+
+
+        data['Header'] = ('Variable','miss', 'nans', 'infs', 'fill')
+        data['Total'] = (nmiss, nanns, infs, fills)
+        
         bad_data = {}
         bad_data['nmiss'] = nmiss
         bad_data['nanns'] = nanns
@@ -853,6 +866,7 @@ class Datastream:
         return {
             'type': 'summary',
             'bad_data': bad_data,
+            'data': data,
         }
 
     def jsonify(self):

--- a/ncr/datastream.py
+++ b/ncr/datastream.py
@@ -520,7 +520,7 @@ class TimedData:
         ninfs = 0
         nfill = 0
         for ns in self.data.values():
-            a = ns.get_nifs()
+            a = (0, 0, 0, 0) if ns is None else ns.get_nifs()
             nmiss += a[0] 
             nnans += a[1]
             ninfs += a[2]

--- a/ncr/datastream.py
+++ b/ncr/datastream.py
@@ -790,7 +790,6 @@ class Datastream:
         for key, value in self.variables.items():
             if type(value) is Variable:
                 a, b, c, d = value.get_nifs()
-                print(a, b, c, d)
                 nmiss += a
                 nanns += b
                 infs  += c

--- a/ncr/datastreamdiff.py
+++ b/ncr/datastreamdiff.py
@@ -523,7 +523,7 @@ class DatastreamDiff:
         fills = 0 
 
         for key, value in self.variables.items():
-            if value is VariableDiff:
+            if type(value) is VariableDiff:
                 a, b, c, d = value.get_nifs()
                 nmiss += a
                 nanns += b

--- a/ncr/datastreamdiff.py
+++ b/ncr/datastreamdiff.py
@@ -538,12 +538,13 @@ class DatastreamDiff:
                 newrow.append(row[1] - row[0])  # diff
                 different_times.append(newrow)
 
-        nmiss = 0
-        nanns = 0 
-        infs = 0   
-        fills = 0 
-
+        nmiss, nanns, infs, fills = 0, 0, 0, 0
         nmiss2, nanns2, infs2, fills2 = 0, 0, 0, 0
+
+        '''print('----\tOLD\tDATA\t----\t----\tNEW\tDATA\t----\t----')
+        print('nmiss\tnann\tinfs\tfill\tnmiss\tnann\tinfs\tfill\tNAME')'''
+
+        data = {}
 
         for key, value in self.variables.items():
             if type(value) is VariableDiff:
@@ -556,6 +557,16 @@ class DatastreamDiff:
                 nanns2 += f
                 infs2  += g
                 fills2 += h
+
+                if a >0 or b>0 or c>0 or d>0 or e>0 or f>0 or g>0 or h>0:
+                    data[value.name] = (a,b,c,d,'',e,f,g,h)
+                    '''for x in (a,b,c,d,e,f,g,h,value.name):
+                        print(x, end='\t')
+                    print()'''
+
+        # the '' breaks in these tuples are intentional: they give space to their respective tables
+        data['Header'] = ('Variable','miss', 'nans', 'infs', 'fill', '', 'miss', 'nans', 'infs', 'fill')
+        data['Total'] = (nmiss, nanns, infs, fills, '',nmiss2, nanns2, infs2, fills2)            
 
         bad_data = {}
         bad_data['nmiss'] = nmiss
@@ -573,7 +584,8 @@ class DatastreamDiff:
             'type': 'summary',
             'different_times': different_times,
             'bad_data': bad_data,
-            'bad_data2': bad_data2
+            'bad_data2': bad_data2,
+            'data': data,
         }
 
     def jsonify(self):

--- a/ncr/datastreamdiff.py
+++ b/ncr/datastreamdiff.py
@@ -523,11 +523,12 @@ class DatastreamDiff:
         fills = 0 
 
         for key, value in self.variables.items():
-            a, b, c, d = value.get_nifs()
-            nmiss += a
-            nanns += b
-            infs  += c
-            fills += d
+            if value is VariableDiff:
+                a, b, c, d = value.get_nifs()
+                nmiss += a
+                nanns += b
+                infs  += c
+                fills += d
 
         bad_data = {}
         bad_data['nmiss'] = nmiss

--- a/ncr/datastreamdiff.py
+++ b/ncr/datastreamdiff.py
@@ -128,8 +128,8 @@ class TimedDataDiff:
         ninfs = 0
         nfill = 0
         for old_ns, new_ns in zip(self.old, self.new):
-            a = old_ns.get_nifs()
-            b = new_ns.get_nifs()
+            a = (0, 0, 0, 0) if old_ns is None else old_ns.get_nifs()
+            b = (0, 0, 0, 0) if new_ns is None else new_ns.get_nifs()
             nmiss += a[0] + b[0]
             nnans += a[1] + b[1]
             ninfs += a[2] + b[2]

--- a/ncr/datastreamdiff.py
+++ b/ncr/datastreamdiff.py
@@ -506,7 +506,7 @@ class DatastreamDiff:
         different_times = []
         for row in self.dimensions['time']:
             # check if new and old values are the same
-            if row[0] == row[1] or row[0] == 0 or row[1] == 0 or row[2] == 0:
+            if row[0] == row[1] or len(row) != 4:
                 continue
             else:
                 # re-order the data
@@ -534,9 +534,6 @@ class DatastreamDiff:
         bad_data['nanns'] = nanns
         bad_data['infs'] =  infs
         bad_data['fills'] = fills
-
-        for key in bad_data:
-            print(key, bad_data[key])
 
         return {
             'type': 'summary',

--- a/ncr/summary.py
+++ b/ncr/summary.py
@@ -183,7 +183,7 @@ class NumDataType:
                     numsum['std'] = np.sqrt(numsum['var']).item() if numsum['var'] is not None and numsum['var'] >= 0 else None
         except:
             pass 
-        
+
         return numsum
 
 class ExStateDataType:

--- a/ncreview.py
+++ b/ncreview.py
@@ -139,15 +139,7 @@ def main(argv):
     parser.add_argument('--readers', type=int, default=10,
                         help='Specify number of concurrent file readers.  Will accept a number between %d and %d (inclusive).' % (min_readers, max_readers))
 
-    # edit
-    parser.add_argument('--dev', action='store_true',
-                        help='For running on a local host, dev. only')
-
     args = parser.parse_args()
-
-    # edit
-    global DEVELOPMENT
-    DEVELOPMENT = args.dev
 
         # Get absolute directory paths...
         # This will be important for the webpage to know where the datastreams
@@ -400,9 +392,6 @@ def main(argv):
     print('https://engineering.arm.gov' +
           location + '/ncreview/?' + url_string)
     print("")
-
-    if DEVELOPMENT:
-        print('DEVELOPMENT LINK: \n' + 'localhost/web/index.html?' + url_string + '\n\n')
 
     return 0
 

--- a/web/css/ncreview.css
+++ b/web/css/ncreview.css
@@ -82,14 +82,18 @@ th {
 	padding: 0px 10px;
 }
 
-th.changed {
+th, td.changed {
 	color:#22b;
 }
-th.added {
+th, td.added {
 	color:#2b2;
 }
-th.removed {
+th, td.removed {
 	color:#b22;
+}
+
+th, td.same {
+	color:#000;
 }
 
 .right {

--- a/web/css/ncreview.css
+++ b/web/css/ncreview.css
@@ -82,17 +82,17 @@ th {
 	padding: 0px 10px;
 }
 
-th, td.changed {
+th.changed, td.changed {
 	color:#22b;
 }
-th, td.added {
+th.added, td.added {
 	color:#2b2;
 }
-th, td.removed {
+th.removed, td.removed {
 	color:#b22;
 }
 
-th, td.same {
+th.same, td.same {
 	color:#000;
 }
 

--- a/web/js/datastream.js
+++ b/web/js/datastream.js
@@ -45,14 +45,14 @@ function render_datastream_diff(parent, object) {
 function render_summary(parent, object) {
 	// render the summary details menu
 		
-		var details = parent.append('div');
-		
-		details = details.append('div')
-			.style('padding-left', '1.25em');
+	var details = parent.append('div');
+	
+	details = details.append('div')
+		.style('padding-left', '1.25em');
 
-		if(object['bad_data'].length != 0) {
-			var par = details.append('p').text('Bad Data');
-			var table = details.append('table').attr('id', 'bad_data');
+	if(object['bad_data'].length != 0) {
+		var par = details.append('p').text('Bad Data');
+		var table = details.append('table').attr('id', 'bad_data');
 
 		for(let key of ['nmiss', 'nanns', 'infs', 'fills']) {
 			var tr = table.append('tr');
@@ -62,9 +62,9 @@ function render_summary(parent, object) {
 	}
 
 	if(object['different_times'].length != 0){
+		var par = details.append('p').text('Changes is Dimensions-time');
+
 		var table = details.append('table');
-		var caption = table.append('caption')
-			.text('Changes in Dimensions-time');
 		// note that we can read data from object['ranodm_text']
 		var tr = table.append('tr');
 		tr.append('th').text('Date');
@@ -83,7 +83,7 @@ function render_summary(parent, object) {
 			tr2.append('td').text(String(epoch2utc(date)).substring(4, 15));
 			tr2.append('td').text(old);
 			tr2.append('td').text(_new);
-			tr2.append('td').text(diff);
+			tr2.append('td').text(diff).style('color', diff > 0 ? '#00642e' : 'b30006');
 		}
 	}
 }

--- a/web/js/datastream.js
+++ b/web/js/datastream.js
@@ -52,7 +52,18 @@ function render_summary(parent, object) {
 		.style('border-top', '1px solid black');
 
 	if(object['bad_data'].length != 0) {
-		var par = details.append('p').text('Bad Data. The sums of each old/new column in each chart in Variables.');
+		var par = details.append('p').text('Old Bad Data. The sums of each old column in each chart in Variables.');
+		var table = details.append('table').attr('id', 'bad_data');
+
+		for(let key of ['nmiss', 'nanns', 'infs', 'fills']) {
+			var tr = table.append('tr');
+			tr.append('th').text(key).style('color', object['bad_data'][key] > 0 ? '#22b' : null).style('text-align', 'right');
+			tr.append('td').text(object['bad_data'][key]);
+		}
+	}
+
+	if(object['bad_data2'].length != 0) {
+		var par = details.append('p').text('New Bad Data. The sums of each new column in each chart in Variables.');
 		var table = details.append('table').attr('id', 'bad_data');
 
 		for(let key of ['nmiss', 'nanns', 'infs', 'fills']) {

--- a/web/js/datastream.js
+++ b/web/js/datastream.js
@@ -44,33 +44,33 @@ function render_datastream_diff(parent, object) {
 
 function render_summary(parent, object) {
 	// render the summary details menu
-		
 	var details = parent.append('div');
+	details.append('h1').text('Summary').style('color', '#ff6600');
 	
 	details = details.append('div')
-		.style('padding-left', '1.25em');
+		//.style('padding-left', '1.25em')
+		.style('border-top', '1px solid black');
 
 	if(object['bad_data'].length != 0) {
-		var par = details.append('p').text('Bad Data');
+		var par = details.append('p').text('Bad Data. The sums of each old/new column in each chart in Variables.');
 		var table = details.append('table').attr('id', 'bad_data');
 
 		for(let key of ['nmiss', 'nanns', 'infs', 'fills']) {
 			var tr = table.append('tr');
-			tr.append('th').text(key).style('color', object['bad_data'][key] != 0 ? '#22b' : null);
+			tr.append('th').text(key).style('color', object['bad_data'][key] > 0 ? '#22b' : null).style('text-align', 'right');
 			tr.append('td').text(object['bad_data'][key]);
 		}
 	}
 
 	if(object['different_times'].length != 0){
-		var par = details.append('p').text('Changes is Dimensions-time');
+		var par = details.append('p').text('Changes in Dimensions-time. The hard-to-see blue lines in the timeline.');
 
 		var table = details.append('table');
-		// note that we can read data from object['ranodm_text']
 		var tr = table.append('tr');
-		tr.append('th').text('Date');
-		tr.append('th').text('Old');
-		tr.append('th').text('New');
-		tr.append('th').text('Diff');
+		tr.append('th').text('Date').style('text-align', 'left');
+		tr.append('th').text('Old').style('text-align', 'right');
+		tr.append('th').text('New').style('text-align', 'right');
+		tr.append('th').text('Diff').style('text-align', 'right');
 
 		for (var i in object['different_times']) {
 			var arr = object['different_times'][i];
@@ -81,9 +81,9 @@ function render_summary(parent, object) {
 
 			var tr2 = table.append('tr');
 			tr2.append('td').text(String(epoch2utc(date)).substring(4, 15));
-			tr2.append('td').text(old);
-			tr2.append('td').text(_new);
-			tr2.append('td').text(diff).style('color', diff > 0 ? '#00642e' : 'b30006');
+			tr2.append('td').text(old).style('text-align', 'right');
+			tr2.append('td').text(_new).style('text-align', 'right');
+			tr2.append('td').text(diff).style('color', diff > 0 ? '#00642e' : 'b30006').style('text-align', 'right');
 		}
 	}
 }

--- a/web/js/datastream.js
+++ b/web/js/datastream.js
@@ -43,17 +43,19 @@ function render_datastream_diff(parent, object) {
 
 
 function render_summary(parent, object) {
-	// render the summary details menu
-	var details = parent.append('div');
-	details.append('h1').text('Summary').style('color', '#ff6600');
+
+	var main_div = parent.append('div');
+	main_div.append('h1').text('Summary').style('color', '#ff6600');
 	
-	details = details.append('div')
-		//.style('padding-left', '1.25em')
+	div = main_div.append('div')
 		.style('border-top', '1px solid black');
 
-	if(object['bad_data'].length != 0) {
-		var par = details.append('p').text('Old Bad Data. The sums of each old column in each chart in Variables.');
-		var table = details.append('table').attr('id', 'bad_data');
+	
+
+	if(object['bad_data']) {
+
+		var par = div.append('p').text('Old Bad Data. The sums of each old column of each chart in Variables.');
+		var table = div.append('table').attr('id', 'bad_data');
 
 		for(let key of ['nmiss', 'nanns', 'infs', 'fills']) {
 			var tr = table.append('tr');
@@ -62,21 +64,126 @@ function render_summary(parent, object) {
 		}
 	}
 
-	if(object['bad_data2'].length != 0) {
-		var par = details.append('p').text('New Bad Data. The sums of each new column in each chart in Variables.');
-		var table = details.append('table').attr('id', 'bad_data');
+	if(object['bad_data2']) {
+		var par = div.append('p').text('New Bad Data. The sums of each new column of each chart in Variables.');
+		var table = div.append('table').attr('id', 'bad_data');
 
 		for(let key of ['nmiss', 'nanns', 'infs', 'fills']) {
 			var tr = table.append('tr');
-			tr.append('th').text(key).style('color', object['bad_data'][key] > 0 ? '#22b' : null).style('text-align', 'right');
-			tr.append('td').text(object['bad_data'][key]);
+			tr.append('th').text(key).style('color', object['bad_data2'][key] > 0 ? '#22b' : null).style('text-align', 'right');
+			tr.append('td').text(object['bad_data2'][key]);
 		}
+	}
+
+	
+
+	if(object['data']) {
+
+		LENGTH = 0;
+		for(var x in object['data']['Header']) {
+			LENGTH = x;
+		}
+
+		var sorted = [];
+		for(var key in object['data']) {
+    		sorted[sorted.length] = key;
+		}
+		sorted.sort();
+
+		var par = div.append('p').text('A more-detailed analysis of misses, NaNs, INFs, and fills.');
+		var table = div.append('table').attr('id', 'data');
+
+		if(LENGTH > 5) {
+			var tr = table.append('tr');
+			tr.append('td').text('');
+			tr.append('td').text('OLD DATA').attr('colspan', '4').style('text-align', 'center');
+			tr.append('td').text('');
+			tr.append('td').text('NEW DATA').attr('colspan', '4').style('text-align', 'center');
+		}
+
+		tr = table.append('tr');
+
+		for(var value of object['data']['Header']) {
+			tr.append('th').text(value).style('text-align', 'left');
+		}
+
+		for(var key of sorted) {
+			if(key === 'Total' || key === 'Header') {
+				continue;
+			}
+
+			tr = table.append('tr');
+			tr.append('td').text(key);
+			var i = 0;
+			for(var value of object['data'][key]) {
+				var cls = 'same';
+
+				if (i >=1 && i <= 4 && LENGTH > 5) {
+					if(value === object['data'][key][i + 5]) {
+						cls = 'same';
+					}
+					else if(value > object['data'][key][i + 5]) {
+						cls = 'added';	// green
+					}
+					else if (value < object['data'][key][i + 5]){
+						cls = 'removed';	// red
+					}	
+				}
+				else if (i >= 6 && i <= 9 && LENGTH > 5) {
+					if(value === object['data'][key][i - 5]) {
+						cls = 'same';
+					}
+					else if(value > object['data'][key][i - 5]) {
+						cls = 'added';
+					}
+					else if (value < object['data'][key][i - 5]){
+						cls = 'removed';
+					}	
+				}
+
+				tr.append('td').text(value).style('text-align','right').attr('class', cls);
+				i++;
+			}
+		}
+
+		var i = 0;
+		tr = table.append('tr');
+		tr.append('td').text('Total').style('text-align', 'left').style('font-weight', 'bold');
+		for(var value of object['data']['Total']) {
+			var cls = 'same';
+			if (i >=0 && i <= 3 && LENGTH > 5) {
+				if(value === object['data']['Total'][i + 5]) {
+					cls = 'same';
+				}
+				else if(value > object['data']['Total'][i + 5]) {
+					cls = 'added';
+				}
+				else if (value < object['data']['Total'][i + 5]){
+					cls = 'removed';
+				}	
+			}
+			else if (i >= 5 && i <= 8 && LENGTH > 5) {
+				if(value === object['data']['Total'][i - 5]) {
+					cls = 'same';
+				}
+				else if(value > object['data']['Total'][i - 5]) {
+					cls = 'added';
+				}
+				else if (value < object['data']['Total'][i - 5]){
+					cls = 'removed';
+				}	
+			}
+
+			tr.append('td').text(value).style('text-align', 'right').style('font-weight', 'bold').attr('class', cls);
+			i++;
+		}
+		
 	}
 
 	if(object['different_times'].length != 0){
-		var par = details.append('p').text('Changes in Dimensions-time. The hard-to-see blue lines in the timeline.');
+		var par = div.append('p').text('Changes in Dimensions-time. The hard-to-see blue lines in the timeline.');
 
-		var table = details.append('table');
+		var table = div.append('table');
 		var tr = table.append('tr');
 		tr.append('th').text('Date').style('text-align', 'left');
 		tr.append('th').text('Old').style('text-align', 'right');
@@ -94,7 +201,7 @@ function render_summary(parent, object) {
 			tr2.append('td').text(String(epoch2utc(date)).substring(4, 15));
 			tr2.append('td').text(old).style('text-align', 'right');
 			tr2.append('td').text(_new).style('text-align', 'right');
-			tr2.append('td').text(diff).style('color', diff > 0 ? '#00642e' : 'b30006').style('text-align', 'right');
+			tr2.append('td').text(diff).style('color', diff > 0 ? '00642e' : 'b30006').style('text-align', 'right');
 		}
 	}
 }

--- a/web/js/structure.js
+++ b/web/js/structure.js
@@ -38,7 +38,6 @@ function render_object(parent, object) {
     if (!render.hasOwnProperty(object.type)) {
         throw new Error('Unrecognized object type: '+object.type);
     }
-    console.log(object);
     render[object.type](parent, object);
 }
 


### PR DESCRIPTION
Re-vamped the entire summary feature. All known bugs have been resolved. 
## New Features
- Partitioned miss, nans, infs, fills chart
    - Old Data
    - New Data
    - Color Coded!
- Added a very precise analysis of where bad data comes from
    - Even has colors to make reading the chart faster and easier on the eyes
- Fixed Jan 1 1970 bug with Dimensions-time table
    - Also has colors
#### Changed the way summary packets are written to .json for summary to read
Still backwards compatible, however some recent ncreviews (i.e. ones used for testing in development by Killian, Easton, and I) will have summaries with some rendering errors. Old ncreviews should work well with the new javascript code––only new ncreviews will render all of the features.
#### Discovered that ncgen does not work anymore!
Well, ncgen does still work, however some features it had no longer function as intended. The most noticeable was when I edited a .cdl file, changing values from normal values to -Infinityf or NaN. In this case, the new .cdf/.nc file wouldn't contain infinities or NaNs: the new binary files contained very large floats (9.9 e 28 or so) and fills respectively. This is not a problem with this merge, I would just like to address this issue and understand that making data with ncgen will not always work. I have a script written to add and test infinities and NaNs. 